### PR TITLE
interval in seconds, setInterval(...) expects ms

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -186,7 +186,7 @@ export class TypeormStore extends Store {
     interval = interval || this.expirationInterval;
 
     this.clearExpirationInterval();
-    this.expirationIntervalId = setInterval(this.clearExpiredSessions, interval);
+    this.expirationIntervalId = setInterval(this.clearExpiredSessions, interval * 1000);
   };
 
   /**


### PR DESCRIPTION
Thanks for providing this code. Noticed a small bug that causes clearExpiredSessions to be called 1000x more often than intended. Hope this helps.