### PR TITLE
Fix a discrepancy in the expirationInterval

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm-store",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A TypeORM-based store for express-session",
   "main": "lib/typeormStore.js",
   "typings": "typings/index.d.ts",

--- a/src/store.ts
+++ b/src/store.ts
@@ -186,7 +186,7 @@ export class TypeormStore extends Store {
     interval = interval || this.expirationInterval;
 
     this.clearExpirationInterval();
-    this.expirationIntervalId = setInterval(this.clearExpiredSessions, interval);
+    this.expirationIntervalId = setInterval(this.clearExpiredSessions, interval * 1000);
   };
 
   /**


### PR DESCRIPTION
The `expirationInterval` config option is actually set in milliseconds, despite the doc comment indicating that it is in seconds. This is a pretty significant discrepancy: supplying an `expirationInterval` of `60` would result in a DB call every 60 milliseconds, not every 60 seconds as expected.

This PR updates the expiration logic to behave as documented by updating the interval passed to the [setInterval](https://nodejs.org/api/timers.html#timers_setinterval_callback_delay_args) function.

Since this change would significantly alter expiration intervals in the wild, I opted to bump a full major version.