### PR TITLE
bumped typeorm peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     ]
   },
   "peerDependencies": {
-    "typeorm": "^0.2.7"
+    "typeorm": "~0.3.0"
   },
   "devDependencies": {
     "@types/express-session": "^1.15.11",


### PR DESCRIPTION
Fixes #25 
Tested with `typeorm@0.3.10` and `typeorm@0.3.11`.